### PR TITLE
Enhance Undo Functionality: Add Undo Support for Eraser Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,9 @@
           eraserIndicator.style.display = "none";
           startDrawing(x, y);
           isDrawing = true;
+          saveState();
         } else if (currentMode === "eraser") {
+          saveState();
           setIndicatorPosition(eraserIndicator, event);
         }
       }
@@ -446,7 +448,6 @@
         fgCtx.lineJoin = "round";
         fgCtx.beginPath();
         fgCtx.moveTo(x, y);
-        saveState();
       }
 
       function drawLine(x, y) {


### PR DESCRIPTION
This pull request enhances the undo functionality by adding support for the Eraser mode. Previously, the undo feature was only available for the Pencil mode. With this update, users can now undo their actions when using the Eraser tool as well.

### Key Changes:
- Added `saveState()` call when starting the Eraser tool to ensure that the current canvas state is saved before any erasing action.
- Moved the `saveState()` call out of the drawing start logic to ensure it's invoked for both Pencil and Eraser modes.
- Simplified the code by removing redundant `saveState()` calls in the Pencil mode logic.

These changes improve the user experience by providing a consistent undo functionality across different drawing modes.